### PR TITLE
Small output improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=0.8.0
+potVersion=0.8.1
 
 filterName=coffeefilter
 filterVersion=0.8.0
 
 grinderName=coffeegrinder
-grinderVersion=0.8.0
+grinderVersion=0.8.1
 
 xmlresolverVersion=4.2.0
 docbookVersion=5.2b12

--- a/src/main/java/org/nineml/coffeepot/Main.java
+++ b/src/main/java/org/nineml/coffeepot/Main.java
@@ -401,6 +401,9 @@ class Main {
                 }
             } else {
                 serialize(output, doc, outputFormat);
+                if (options.trailingNewlineOnOutput) {
+                    output.println();
+                }
 
                 if (cmain.treeXml != null) {
                     doc.getParseTree().serialize(cmain.treeXml);

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
@@ -27,4 +27,11 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
      * messages will be written to the redirected location.</p>
      */
     public String progressBar = "false";
+
+    /**
+     * Make sure the output ends with a newline?
+     * <p>If this option is true, a newline will be added to the end of the output.
+     * </p>
+     */
+    public boolean trailingNewlineOnOutput = true;
 }

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
@@ -97,6 +97,7 @@ public class ParserOptionsLoader {
 
         options.prettyPrint = "true".equals(getProperty("pretty-print", "false"));
         options.ignoreTrailingWhitespace = "true".equals(getProperty("ignore-trailing-whitespace", "false"));
+        options.trailingNewlineOnOutput = "true".equals(getProperty("trailing-newline-on-output", "true"));
         options.graphviz = getProperty("graphviz", null);
         options.cacheDir = getProperty("cache", null);
 

--- a/src/main/java/org/nineml/coffeepot/utils/ProgressBar.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ProgressBar.java
@@ -103,7 +103,7 @@ public class ProgressBar implements ProgressMonitor {
             return;
         }
         if (istty) {
-            System.out.printf("                                                            \r");
+            System.out.printf("                                                                      \r");
         }
     }
 }


### PR DESCRIPTION
1. Fixed the bug where the progress bar left a few trailing characters on the last line after a parse
2. Added the `trailingNewlineOnOutput` option to force a newline at the end of the output