### PR TITLE
Don't attempt to use URLClassLoader

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=0.10.0
+potVersion=0.10.1
 
 filterName=coffeefilter
 filterVersion=0.10.0

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
@@ -7,7 +7,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -97,24 +96,6 @@ public class ParserOptionsLoader {
                 URL resource = loader.getResource(propfn);
                 options.getLogger().debug("CoffeePot", "Loading properties: %s", resource);
                 return loadFromStream(stream);
-            }
-
-            // The 'java -jar ...' case...
-            URL[] urls = ((URLClassLoader) loader).getURLs();
-            if (urls.length == 1) {
-                fn = urls[0].getPath();
-                int pos = fn.lastIndexOf("/");
-                if (pos >= 0) {
-                    fn = fn.substring(0, pos);
-                }
-                fn = fn + "/" + propfn;
-
-                propfile = new File(fn);
-                //System.err.println("FN2:" + fn);
-                if (propfile.exists() && propfile.canRead()) {
-                    options.getLogger().debug("CoffeePot", "Loading properties: %s", fn);
-                    return loadFromFile(propfile);
-                }
             }
 
             options.getLogger().debug("CoffeePot", "Failed to find nineml.properties");

--- a/src/website/xml/configuration.xml
+++ b/src/website/xml/configuration.xml
@@ -23,13 +23,6 @@ log-levels=CoffeePot:trace,Parser:info
 pretty-print=true
 progress-bar=tty</programlisting>
 
-<note>
-<para>As a special case, if <application>CoffeePot</application> is run
-directly out of the distributed jar file (i.e., <command>java</command> <option>-jar</option> coffeepot-<?version?>.jar …), it will look for 
-<filename>nineml.properties</filename> in the current directory.
-</para>
-</note>
-
 <para>If the file is found and is a usable Java properties file, the
 following options are read from it:</para>
 
@@ -84,6 +77,12 @@ may be used.
 <para>Setting the progress bar to true or false enables or disables it.
 Setting it to “tty” enables it only if the output is going to a “tty”, an
 interactive computer terminal.
+</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><property>prefix-parsing</property> (boolean)</term>
+<listitem>
+<para>If true, a parse will succeed if it matches a prefix of the input.
 </para>
 </listitem>
 </varlistentry>


### PR DESCRIPTION
Close #38 

My trick to load `nineml.properties` in the current directory if the user happened to be running `java -jar ...` doesn't work in Java 9 or later. Just abandon the whole thing, there's a `--config` option now anyway.