### PR TITLE
Fix cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=1.99.7
+potVersion=1.99.8
 
 filterName=coffeefilter
-filterVersion=1.99.7
+filterVersion=1.99.8
 
 grinderName=coffeegrinder
-grinderVersion=1.99.7
+grinderVersion=1.99.8
 
-xmlresolverVersion=4.3.0
+xmlresolverVersion=4.4.0
 docbookVersion=5.2b12
 xslTNGversion=1.7.0-10
 

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptions.java
@@ -33,6 +33,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
      * The cache directory.
      * <p>If this is not null, it should be the name of a directory on the
      * local filesystem that can be used as a cache location.</p>
+     * @return the cache directory
      */
     public String getCacheDir() {
         return cacheDir;
@@ -55,6 +56,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
      * {@link System#out} is redirected. If the value is "tty", no progress messages
      * will be written to the output in this case. If the value is "true", the progress
      * messages will be written to the redirected location.</p>
+     * @return the progress bar display setting.
      */
     public String getProgressBar() {
         return progressBar;
@@ -79,6 +81,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
      * <p>The first character is used for an "empty" space in the progress bar.
      * The last character is used for a "full" space. Any characters in between
      * the first and the last are used for even fractions between 0 and 1.</p>
+     * @return the characters used to create the status bar.
      */
     public String getProgressBarCharacters() {
         return barCharacters;
@@ -104,6 +107,7 @@ public class ParserOptions extends org.nineml.coffeefilter.ParserOptions {
      * Make sure the output ends with a newline?
      * <p>If this option is true, a newline will be added to the end of the output.
      * </p>
+     * @return the trailing newline setting.
      */
     public boolean getTrailingNewlineOnOutput() {
         return trailingNewlineOnOutput;

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
@@ -60,6 +60,7 @@ public class ParserOptionsLoader {
 
     /**
      * Load the options.
+     * @param configFile the name of the configuration file.
      * @return the options initialized from the properties file, if one was found.
      */
     public ParserOptions loadOptions(String configFile) {


### PR DESCRIPTION
Bump to latest APIs.

If a cached grammar can't be loaded, ignore it. Also delete it if we can.