### PR TITLE
Bump versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=1.99.9
+potVersion=1.99.11
 
 filterName=coffeefilter
-filterVersion=1.99.11
+filterVersion=1.99.12
 
 grinderName=coffeegrinder
-grinderVersion=1.99.11
+grinderVersion=1.99.12
 
 xmlresolverVersion=4.5.1
 docbookVersion=5.2CR2
-xslTNGversion=1.8.0
+xslTNGversion=1.8.1
 
 saxonVersion=10.6
 saxonGroup=net.sf.saxon


### PR DESCRIPTION
Update to a `CoffeeGrinder` version that has "fixed" the problem with marks and the GLL parser.