### PR TITLE
Bump versions for new CoffeeFilter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
       force 'xml-apis:xml-apis:1.4.01',
         "${saxonGroup}:${saxonEdition}:${saxonVersion}",
         "org.xmlresolver:xmlresolver:${xmlresolverVersion}",
-        'com.nwalsh:sinclude:4.0.0'
+        'com.nwalsh:sinclude:4.2.1'
     }
   }
 
@@ -51,7 +51,7 @@ configurations.all {
     force 'xml-apis:xml-apis:1.4.01',
       "${saxonGroup}:${saxonEdition}:${saxonVersion}",
       "org.xmlresolver:xmlresolver:${xmlresolverVersion}",
-      'com.nwalsh:sinclude:4.0.0'
+      'com.nwalsh:sinclude:4.2.1'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=1.99.11
+potVersion=1.99.12
 
 filterName=coffeefilter
-filterVersion=1.99.12
+filterVersion=1.99.13
 
 grinderName=coffeegrinder
 grinderVersion=1.99.12
 
-xmlresolverVersion=4.5.1
-docbookVersion=5.2CR2
-xslTNGversion=1.8.1
+xmlresolverVersion=4.6.0
+docbookVersion=5.2CR3
+xslTNGversion=1.11.1
 
-saxonVersion=10.6
+saxonVersion=11.4
 saxonGroup=net.sf.saxon
 saxonEdition=Saxon-HE


### PR DESCRIPTION
Update CoffeePot to use CoffeeFilter 1.99.13 which supports erratum E001.