### PR TITLE
Publish version 2.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,12 +194,12 @@ task zipDist(type: Zip) {
 dist.finalizedBy zipDist
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
+  archiveClassifier = 'javadoc'
   from javadoc.destinationDir
 }
 
 task sourcesJar(type: Jar, dependsOn: ['generateBuildConfig']) {
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.main.allSource
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 potTitle=CoffeePot
 potName=coffeepot
-potVersion=2.0.0
+potVersion=2.0.3
 
 filterName=coffeefilter
-filterVersion=2.0.0
+filterVersion=2.0.3
 
 grinderName=coffeegrinder
 grinderVersion=2.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/nineml/coffeepot/Main.java
+++ b/src/main/java/org/nineml/coffeepot/Main.java
@@ -41,6 +41,7 @@ class Main {
     boolean parseError = false;
     InvisibleXmlParser parser;
     OutputFormat outputFormat;
+    private static final int UnicodeBOM = 0xFEFF;
 
     public static void main(String[] args) {
         Main driver = new Main();
@@ -420,12 +421,18 @@ class Main {
 
                 // I'm not confident this is the most efficient way to do this, but...
                 StringBuilder sb = new StringBuilder(1024);
+                boolean ignoreBOM = options.getIgnoreBOM() && "utf-8".equalsIgnoreCase(cmain.encoding);
                 int inputchar = reader.read();
+                if (inputchar != -1) {
+                    if (!ignoreBOM || inputchar != UnicodeBOM) {
+                        sb.append((char) inputchar);
+                    }
+                    inputchar = reader.read();
+                }
                 while (inputchar != -1) {
                     sb.append((char) inputchar);
                     inputchar = reader.read();
                 }
-
                 input = sb.toString();
             } catch (IOException ex) {
                 System.err.println("Failed to read input: " + cmain.inputFile);

--- a/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
+++ b/src/main/java/org/nineml/coffeepot/utils/ParserOptionsLoader.java
@@ -33,6 +33,7 @@ public class ParserOptionsLoader {
         PROPERTY_NAMES.add("default-log-level");
         PROPERTY_NAMES.add("graphviz");
         PROPERTY_NAMES.add("ignore-trailing-whitespace");
+        PROPERTY_NAMES.add("ignore-bom");
         PROPERTY_NAMES.add("log-levels");
         PROPERTY_NAMES.add("pedantic");
         PROPERTY_NAMES.add("prefix-parsing");
@@ -121,6 +122,7 @@ public class ParserOptionsLoader {
 
         options.setPrettyPrint(getBooleanProperty("pretty-print"));
         options.setIgnoreTrailingWhitespace(getBooleanProperty("ignore-trailing-whitespace"));
+        options.setIgnoreBOM(getBooleanProperty("ignore-bom"));
         options.setTrailingNewlineOnOutput(getBooleanProperty("trailing-newline-on-output", true));
         options.setPedantic(getBooleanProperty("pedantic"));
         options.setAssertValidXmlNames(getBooleanProperty("assert-valid-xml-names", true));

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -7,6 +7,28 @@
 
 <revhistory>
 <revision>
+  <revnumber>2.0.3</revnumber>
+  <date>2023-04-15</date>
+  <revdescription>
+    <itemizedlist>
+      <listitem>
+        <para>Updated to use CoffeeFilter version 2.0.3 which corrects errors in
+        the serialization of control characters in attributes and text content (and changes
+        the serialization of <literal>&gt;</literal> to always be <literal>&amp;gt;</literal>).
+        </para>
+      </listitem>
+      <listitem>
+        <para>If a UTF-8 grammar or input file begins with a byte-order-mark (BOM), the
+        BOM is ignored. A new configuration property <literal>ignore-bom</literal> can be
+        set to <literal>false</literal> to disable this behavior.</para>
+      </listitem>
+      <listitem>
+        <para>The build system has been updated to use Gradle version 8.0.2.</para>
+      </listitem>
+    </itemizedlist>
+  </revdescription>
+</revision>
+<revision>
   <revnumber>2.0.0</revnumber>
   <date>2023-04-10</date>
   <revremark>Making the 2.x code base the current release.</revremark>


### PR DESCRIPTION
* Update to CoffeeFilter 2.0.3 to correct errors in the serialization of control characters
* Add an `ignore-bom` configuration property (the BOM is ignored by default)
* Updated Gradle build to 8.0.2