### PR TITLE
Make it easier for builds from forks to succeed in actions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,4 +1,4 @@
-name: build-branch
+name: build-pot
 on: push
 
 jobs:
@@ -38,6 +38,8 @@ jobs:
     env:
       HAVE_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN != '' }}
       HAVE_GPGKEYURI: ${{ secrets.ACCESS_TOKEN != '' && secrets.GPGKEYURI != '' }}
+      HAVE_SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY != '' }}
+      CAN_PUBLISH: ${{ secrets.ACCESS_TOKEN != '' && secrets.GPGKEYURI != '' && secrets.SSH_PRIVATE_KEY != '' }}
       CIWORKFLOW: yes
       CI_SHA1: ${{ github.sha }}
       CI_BUILD_NUM: ${{ github.run_number }}
@@ -48,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup SSH key
+        if: ${{ env.HAVE_SSH_PRIVATE_KEY == 'true' }}
         uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -62,8 +65,8 @@ jobs:
           ./gradlew dist website
 
       - name: Deploy main to gh-pages
-        if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' }}
         uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' }}
         with:
           folder: build/website
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -72,7 +75,7 @@ jobs:
 
       - name: Publish release
         uses: softprops/action-gh-release@v1
-        if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
+        if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         with:
           draft: false
           prerelease: false
@@ -81,7 +84,7 @@ jobs:
             build/distributions/coffeepot-${{ env.CI_TAG }}.zip
 
       - name: Publish to Sonatype
-        if: ${{ env.HAVE_GPGKEYURI == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
+        if: ${{ env.CAN_PUBLISH == 'true' && env.CI_BRANCH == 'main' && env.CI_TAG != '' }}
         run: |
           curl -s -o secret.gpg ${{ secrets.GPGKEYURI }}
           ./gradlew -PsonatypeUsername=${{ secrets.SONATYPEUSER }} \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,12 +50,6 @@ jobs:
       CI_TAG: ${{ needs.check_branch.outputs.tag }}
       CI_PULL: ${{ github.event.number }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup SSH key
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Checkout the branch
         uses: actions/checkout@v3
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "website"]
-	path = website
-	url = git@github.com:nineml/website.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "website"]
+	path = website
+	url = https://github.com/nineml/website.git


### PR DESCRIPTION
1. Don't attempt to use the SSH private key if there isn't one
2. Switch the website repo to https: so that it can be checked out without authentication
